### PR TITLE
[build] use latest .NET 6 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   AndroidSupportedAbis: arm64-v8a
   AndroidPackageFormat: apk
   RID: android-arm64
-  DotNet.Version: 6.0.100
+  DotNet.Version: 6.0.x
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
     inputs:
       version: $(DotNet.Version)
 
-  - bash: dotnet workload install maui android-aot --verbosity diag
+  - bash: dotnet workload install maui --verbosity diag
     displayName: install optional workloads
 
   - bash: >


### PR DESCRIPTION
This should roll this repo forward to 6.0.201 and .NET MAUI Preview 14.